### PR TITLE
fix: remove double BrowserRouter causing black screen in production

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,11 +2,4 @@ import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
 
-// main.tsx or src/main.tsx
-import { BrowserRouter } from "react-router-dom";
-
-createRoot(document.getElementById("root")!).render(
-  <BrowserRouter>
-    <App />
-  </BrowserRouter>
-);
+createRoot(document.getElementById("root")!).render(<App />);


### PR DESCRIPTION
- Remove nested BrowserRouter from main.tsx (App.tsx already provides routing)
- Fixes React Router nesting error that prevented app from rendering
- TODO: Remove temporary sourcemaps after verification